### PR TITLE
ignore warning 5045

### DIFF
--- a/code/build.bat
+++ b/code/build.bat
@@ -4,7 +4,7 @@ pushd ..\build
 del *.pdb > NUL 2> NUL
 echo WAITING FOR PDB > lock.tmp
 
-set warnings_to_ignore=-wd4201 -wd4204 -wd4255 -wd4668 -wd4820 -wd4100 -wd4189 -wd4711 -wd4710 -wd4101 -wd4296 -wd4311 -wd4115 -wd4702 -wd4456 -wd4555
+set warnings_to_ignore=-wd4201 -wd4204 -wd4255 -wd4668 -wd4820 -wd4100 -wd4189 -wd4711 -wd4710 -wd4101 -wd4296 -wd4311 -wd4115 -wd4702 -wd4456 -wd4555 -wd5045
 
 REM Asset Cooker Build
 REM cl -nologo -O2 -Zi -FC -WX -Wall %warnings_to_ignore% ..\code\cooker.c /link user32.lib gdi32.lib -incremental:no -opt:ref


### PR DESCRIPTION
Visual Studio Build Tools 2019 produces the following output when running `build.bat` in a `vcvarsall.bat` cmd window.

```
win32_platform.c
C:\home\code\not_my_code\break_arcade_games_out\code\math.c(16) : error C2220: the following warning is treated as an error
C:\home\code\not_my_code\break_arcade_games_out\code\math.c(9) : error C2220: the following warning is treated as an error
C:\home\code\not_my_code\break_arcade_games_out\code\math.c(16) : warning C5045: Compiler will insert Spectre mitigation for memory load if /Qspectre switch specified
C:\home\code\not_my_code\break_arcade_games_out\code\math.c(15) : note: index 'val' range checked by comparison on this line
C:\home\code\not_my_code\break_arcade_games_out\code\math.c(16) : note: feeds call on this line
C:\home\code\not_my_code\break_arcade_games_out\code\math.c(9) : warning C5045: Compiler will insert Spectre mitigation for memory load if /Qspectre switch specified
C:\home\code\not_my_code\break_arcade_games_out\code\math.c(8) : note: index 'val' range checked by comparison on this line
C:\home\code\not_my_code\break_arcade_games_out\code\math.c(9) : note: feeds call on this line
```
...followed by several more lines with similar messages about lines in `stb_image.h` and `ogg_importer.h`.

This PR adds ` -wd5045` to the `warnings_to_ignore` variable, which fixed the build, (at least on my setup.)